### PR TITLE
Add extra items for HA Energy dashboard, bug fixes & explain create API token

### DIFF
--- a/GE-DaysFullDataPoints.ps1
+++ b/GE-DaysFullDataPoints.ps1
@@ -12,7 +12,7 @@ $DatePick = $DateFirst
 $DateCount = Read-Host -Prompt "Enter number of days"
 $page = 1
 $pageSize = 1000
-$DataPointsStr = "Date,Solar,Import,Export,Consumption,Battery`r`n"
+$DataPointsStr = "Date,Solar Today,Solar Total,Import Today,Import Total,Export Today,Export Total,Consumption Today,Consumption Total,Charge Today,Discharge Today,Battery SoC %"
 
 ########end user input#############
 
@@ -28,15 +28,27 @@ function WriteDateFullPickData {
 	$Giv_En =  Invoke-RestMethod -Method 'GET' -Uri https://api.givenergy.cloud/v1/inverter/$SerialNum/data-points/$DatePick"?"page=$page"&"pageSize=$pageSize -Headers $headers_Giv_En
 	$Giv_Obj = $Giv_En | ConvertTo-Json -depth 10 | ConvertFrom-Json
 
-	$last = $Giv_Obj.Data.Count - 1
+	$last = $Giv_Obj.Data.Count
 	for($rec = 0; $rec -lt $last; $rec++) {
-		$rectime = $Giv_Obj.Data[$rec].time
-		$solar = $Giv_Obj.Data[$rec].today.solar
-		$import = $Giv_Obj.Data[$rec].today.grid.import
-		$export = $Giv_Obj.Data[$rec].today.grid.export
-		$consumption = $Giv_Obj.Data[$rec].today.consumption
-		$battery = $Giv_Obj.Data[$rec].power.battery.percent
-		$parArray = @($rectime,$solar,$import,$export,$consumption,$battery)
+        # GivEnergy portal holds all data with date/times in UTC, so in summertime a 'day' starts and ends at 23:00 UTC
+        # Extract date/time from GivEnergy data and convert to datetime object which automatically converts to local time (and adjusts for summertime offset)
+        $rectime = [datetime]::Parse($Giv_Obj.Data[$rec].time)
+
+        # extract other inverter data items we are interested in
+		$solarToday = $Giv_Obj.Data[$rec].today.solar
+		$importToday = $Giv_Obj.Data[$rec].today.grid.import
+		$exportToday = $Giv_Obj.Data[$rec].today.grid.export
+		$consumptionToday = $Giv_Obj.Data[$rec].today.consumption
+        $chargeToday = $Giv_Obj.Data[$rec].today.battery.charge
+        $dischargeToday = $Giv_Obj.Data[$rec].today.battery.discharge
+		$batterySoC = $Giv_Obj.Data[$rec].power.battery.percent
+		$solarTotal = $Giv_Obj.Data[$rec].total.solar
+		$importTotal = $Giv_Obj.Data[$rec].total.grid.import
+		$exportTotal = $Giv_Obj.Data[$rec].total.grid.export
+		$consumptionTotal = $Giv_Obj.Data[$rec].total.consumption
+
+		# add the data to the output array
+		$parArray = @($rectime,$solarToday,$solarTotal,$importToday,$importTotal,$exportToday,$exportTotal,$consumptionToday,$consumptionTotal,$chargeToday,$dischargeToday,$batterySoC)
 		$DataPointsStr = $parArray -join ","
 		Add-Content .\FullDataPoints_$DateFirst.txt $DataPointsStr
 	}
@@ -52,7 +64,7 @@ for($index = 0; $index -lt $DateCount; $index++) {
 	$DatePick = $DateObj.ToString('yyyy-MM-dd')
 }
 
-Write-Output "Data Saved to: FullDataPoints_(Date).txt"
+Write-Output "Data Saved to: FullDataPoints_$DateFirst.txt"
 Write-Output "All done - Exit in 5...." 
 start-sleep -s 5
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ There are also python equivalents in the python folder. You may need to install 
 For Windows powershell scripts the easiest way to run is to right click the script file within file explorer.
 For the python programs open a console window and run python <pythonscriptname>
 
+You will need to edit the script before you can use it to add your inverter serial number and a GivEnergy Cloud API key.
+To create an API key, in the GivEnergy Portal:
+- Account Settings
+- Manage Account Security
+- Manage API Tokens
+- Generate New Token
+- Give the token a name, an expiry date and ensure that `api:inverter:data` and `api:meter:data` are selected
+- Create token
+- Click the copy icon to copy the token to your clipboard, then paste it into the script
+
 ## GE-DaysDataPoints
 - Script to extract daily summary for a range of dates to a csv file
 - edit to put in apikey and GivEnergy serial number
@@ -19,7 +29,7 @@ For the python programs open a console window and run python <pythonscriptname>
 - edit to put in apikey and GivEnergy serial number
 - enter first date in yyyy-mm-dd format e.g. 2022-10-01
 - enter number of days required
-- Creates a csv text file with fields for time,solar,import, export,consumption and battery percentage
+- Creates a csv text file with fields for date/time, solar today, solar total, import today, import total, export today, import total, consumption today, consumption total, battery charge today, battery discharge today and battery percentage
 - Other fields can be addded easily by extracting from JSON data object 
 - Works by extracting full data for each day, parsing into data object and iterating over all records
 


### PR DESCRIPTION
There are five sets of changes in this PR:

1. I wanted to use the script to bulk download historical data for populating the Home Assistant Energy dashboard, so expanded the fields written to the file
2. Discovered that the last record from each day on the GivEnergy portal was being omitted, corrected the loop that was slightly wrong
3. When retrieving data from the GivEnergy portal, all date/times are in UTC so records retrieved for days in the summer are from 23:00 (previous day) to 23:00 (requested day).  Added logic to convert date/times to local time to resolve this problem
4. Changed display of filename written to include the actual filename
5. Added to the readme details of the extra fields and instructions for how to create an API token in the GivEnergy portal